### PR TITLE
Hide description icon if no description present

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -96,9 +96,11 @@ export default function Index({
                 style={{ marginBottom: '8px' }}
               >
                 <div className="ui marginless header">
-                  <span data-tooltip={monitor.description}>
-                    <i className="blue small info circle icon" />
-                  </span>
+                  {monitor.description && (
+                    <span data-tooltip={monitor.description}>
+                      <i className="blue small info circle icon" />
+                    </span>
+                  )}
                   <div className="content">{monitor.name}</div>
                 </div>
                 <MonitorStatusLabel


### PR DESCRIPTION
This hides the info circle from monitors which do not have a description.