### PR TITLE
fix(actions): let deployment pass on missing slack webhook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
           kv_namespace_id=$(wrangler kv:namespace list | jq -c 'map(select(.title | contains("KV_STATUS_PAGE")))' | jq ".[0].id")
           echo "[env.production]" >> wrangler.toml
           echo "kv_namespaces = [{binding=\"KV_STATUS_PAGE\", id=${kv_namespace_id}}]" >> wrangler.toml
+          [ -z "$SECRET_SLACK_WEBHOOK_URL" ] && echo "Secret SECRET_SLACK_WEBHOOK_URL not set, creating dummy one..." && SECRET_SLACK_WEBHOOK_URL="default-gh-action-secret" || true
         secrets: |
           SECRET_SLACK_WEBHOOK_URL
         environment: production

--- a/src/functions/cronTrigger.js
+++ b/src/functions/cronTrigger.js
@@ -42,7 +42,7 @@ export async function processCronTrigger(event) {
       console.log('Saving changed state..')
 
       // first try to notify Slack in case fetch() or other limit is reached
-      if (typeof SECRET_SLACK_WEBHOOK_URL !== 'undefined') {
+      if (typeof SECRET_SLACK_WEBHOOK_URL !== 'undefined' && SECRET_SLACK_WEBHOOK_URL !== 'default-gh-action-secret') {
         await notifySlack(monitor, newMetadata)
       }
 


### PR DESCRIPTION
Fixed by creating dummy secret in `preCommands` as optional secrets are not supported in Wrangler Actions, yet.