### PR TITLE
feat(cron): detect and save location of last check

### DIFF
--- a/pages/api/triggerCron.js
+++ b/pages/api/triggerCron.js
@@ -2,5 +2,5 @@ import { processCronTrigger } from '../../src/functions/cronTrigger'
 
 export default async event => {
   // used only for local debugging
-  //return processCronTrigger()
+  //return processCronTrigger(event)
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -79,12 +79,10 @@ export default function Index({
                 ? config.settings.allmonitorsOperational
                 : config.settings.notAllmonitorsOperational}
             </div>
-            {typeof window !== 'undefined' ? (
+            {kvLastUpdate.metadata && typeof window !== 'undefined' && (
               <div className="black-text">
-                checked {Math.round((Date.now() - kvLastUpdate) / 1000)} sec ago
+                checked {Math.round((Date.now() - kvLastUpdate.value) / 1000)} sec ago (from {kvLastUpdate.metadata.loc})
               </div>
-            ) : (
-              ''
             )}
           </div>
         </div>

--- a/src/functions/cronTrigger.js
+++ b/src/functions/cronTrigger.js
@@ -61,11 +61,16 @@ export async function processCronTrigger(event) {
         await setKV(kvFailedDayStatusKey, null)
       }
     }
-
-    // save last check timestamp
-    await setKV('lastUpdate', Date.now())
   }
-  await gcMonitors(config)
+
+  // save last check timestamp including PoP location
+  const res = await fetch("https://www.cloudflare.com/cdn-cgi/trace")
+  const resText = await res.text()
+  const loc = /loc=([\w]{2})/.exec(resText)[1]
+  await setKV('lastUpdate', Date.now(), {loc})
+
+  // gc monitor statuses
+  event.waitUntil(gcMonitors(config))
 
   return new Response('OK')
 }

--- a/src/functions/helpers.js
+++ b/src/functions/helpers.js
@@ -11,7 +11,7 @@ export async function getMonitorsHistory() {
 }
 
 export async function getLastUpdate() {
-  return await getKV('lastUpdate')
+  return await getKVWithMetadata('lastUpdate')
 }
 
 export async function listKV(prefix = '', cacheTtl = false) {


### PR DESCRIPTION
this is not breaking change, however, it will not render **the last check info** until updated Worker CRON instance saves `lastUpdate` with metadata