### PR TITLE
chore: balance spacing around icons and images

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -61,7 +61,7 @@ export default function Index({
         <link rel="stylesheet" href="./main.css" />
       </Head>
       <div className="ui basic segment container">
-        <h1 className="ui huge header">
+        <h1 className="ui huge title header">
           <img
             className="ui middle aligned tiny image"
             src={config.settings.logo}

--- a/public/main.css
+++ b/public/main.css
@@ -1,7 +1,6 @@
 body {
   background: #eeeeee;
 }
-
 .flex {
   display: flex;
   justify-content: center;
@@ -62,5 +61,8 @@ body {
   background: #f2711c;
 }
 span i.icon {
-  margin: 0 !important;
+  margin: 0 .25em .25em 0 !important;
+}
+.ui.title.header .ui.image {
+  margin-top: -.5em !important;
 }


### PR DESCRIPTION
by default the whitespace around icons and images is a bit off, causing almost everything to look too weighted towards the bottom

with this change applied it should look like this
<img width="1552" alt="Screenshot 2020-11-16 at 22 29 35" src="https://user-images.githubusercontent.com/8055505/99310362-374f2200-285b-11eb-9c33-333f6d48e24e.png">
