### PR TITLE
Supply fallback text for Slack message

### DIFF
--- a/src/functions/helpers.js
+++ b/src/functions/helpers.js
@@ -34,6 +34,7 @@ export async function notifySlack(monitor, operational) {
   const payload = {
     attachments: [
       {
+        fallback: `Monitor ${monitor.name} changed status to ${getOperationalLabel(operational)}`,
         color: operational ? '#36a64f' : '#f2c744',
         blocks: [
           {


### PR DESCRIPTION
This is used as a plain-text summary of the attachment, e.g. in push notifications.

Docs: https://api.slack.com/reference/messaging/attachments#legacy_fields