### PR TITLE
Replace all '-' for  monitor name.

### DIFF
--- a/src/functions/helpers.js
+++ b/src/functions/helpers.js
@@ -64,7 +64,7 @@ export async function notifySlack(monitor, operational) {
 }
 
 export async function notifyTelegram(monitor, operational) {
-  const text = `Monitor *${monitor.name.replace(
+  const text = `Monitor *${monitor.name.replaceAll(
     '-',
     '\\-',
   )}* changed status to *${getOperationalLabel(operational)}*


### PR DESCRIPTION
Fix the monitor name which has multi dashs in telegram alert like this:

```
  - id: corvo-blog
    name: corvo-myseu-cn
    url: 'https://corvo.myseu.cn/'
    method: GET
    expectStatus: 200
```

Just like #25

If someone wanna use telegram, he/she must read this https://core.telegram.org/bots/api#markdownv2-style, and test if the text is valid. 

```bash
In all other places characters '_', '*', '[', ']', '(', ')', '~', '`', '>', '#', '+', '-', '=', '|', '{', '}', '.', '!' 
must be escaped with the preceding character '\'.
```
It's a little hard to debug.

Maybe the repo owner could add a checker which only allows ASCII and dash for the monitor name.

Signed-off-by: corvofeng <corvofeng@gmail.com>