### PR TITLE
Resolve Ongoing Deployment Failures by Refactoring GitHub Actions Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,9 +26,8 @@ jobs:
       with:
         apiToken: ${{ secrets.CF_API_TOKEN }}
         preCommands: |
-          wrangler kv:namespace create KV_STATUS_PAGE
-          apt-get update && apt-get install -y jq
-          export KV_NAMESPACE_ID=$(wrangler kv:namespace list | jq -c 'map(select(.title | contains("KV_STATUS_PAGE")))' | jq -r ".[0].id")
+          wrangler kv:namespace create KV_STATUS_PAGE || true
+          export KV_NAMESPACE_ID=$(npx @cloudflare/wrangler@1 kv:namespace list 2> >(tee stderr.log >&2) | head -1 | node -pe "JSON.parse(fs.readFileSync('/dev/stdin').toString()).find(kv => kv.title.includes('KV_STATUS_PAGE')).id")
           echo "[env.production]" >> wrangler.toml
           echo "kv_namespaces = [{binding=\"KV_STATUS_PAGE\", id=\"${KV_NAMESPACE_ID}\"}]" >> wrangler.toml
           [ -z "$SECRET_SLACK_WEBHOOK_URL" ] && echo "Secret SECRET_SLACK_WEBHOOK_URL not set, creating dummy one..." && SECRET_SLACK_WEBHOOK_URL="default-gh-action-secret" || true


### PR DESCRIPTION
This pull request introduces changes to fix the deployment failures that have been occurring over the past three months. The following critical modifications are implemented:

- The command `wrangler kv:namespace create KV_STATUS_PAGE` is updated with the addition of `|| true` to avoid workflow failure if the KV namespace "KV_STATUS_PAGE" already exists. 

- The `jq` dependency, previously used for processing JSON data, is eliminated. `jq` was causing deployment failures due to `apt update` errors. It is now replaced with an inline Node.js script which performs the same function without causing issues.

- The `cloudflare/wrangler-action` version remains at 1.3.0. An upgrade is not performed as the current version is found to be stable with these changes.

Additionally, the command to extract the `KV_NAMESPACE_ID` now includes `head -1` and a redirection of stderr to stdout (`2> >(tee stderr.log >&2)`). This is done to manage the deprecation warnings caused by the current version of `wrangler`. The `head -1` is used to only process the first line of the `wrangler` command output, effectively ignoring subsequent lines that could include deprecation warnings.
